### PR TITLE
Add CAID artifact contract adapter

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,23 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+      - feature/**
+
+jobs:
+  tests:
+    name: Contract Tests
+    runs-on: windows-latest
+    env:
+      PYTHONDONTWRITEBYTECODE: "1"
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.10"
+      - uses: astral-sh/setup-uv@v5
+      - name: Run contract tests
+        run: uv run --no-project python -m unittest discover -s tests

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.py[cod]

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,8 +15,13 @@ The full demos require MuJoCo and rendering dependencies documented in the READM
 SimCorrect consumes OpenCAD's CAID design artifact and returns parameter patches.
 
 - Use `caid_contract.py` for artifact loading, parameter resolution, and patch creation.
+- Use `mjcf_correction.py` for local MJCF body mass or joint reference edits.
 - Keep problem-specific glue in the problem folder, for example `Problem1_ForearmLength/caid_loop.py`.
 - Map simulation names to design names through `simulation_tags` instead of hardcoding aliases in diagnosis code.
+
+The written contract lives in `docs/CAID_ARTIFACT_CONTRACT.md`.
+
+`opencad.py` is a compatibility facade for older scripts. New code should avoid importing it directly unless compatibility is the goal.
 
 ## Generated Files
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,23 @@
+# Contributing
+
+## Development Setup
+
+SimCorrect is intentionally lightweight at the contract-test layer. Use uv for Python commands.
+
+```bash
+uv run --no-project python -m unittest discover -s tests
+```
+
+The full demos require MuJoCo and rendering dependencies documented in the README. Keep pure contract helpers free of MuJoCo imports so they remain fast to test.
+
+## CAID Contract
+
+SimCorrect consumes OpenCAD's CAID design artifact and returns parameter patches.
+
+- Use `caid_contract.py` for artifact loading, parameter resolution, and patch creation.
+- Keep problem-specific glue in the problem folder, for example `Problem1_ForearmLength/caid_loop.py`.
+- Map simulation names to design names through `simulation_tags` instead of hardcoding aliases in diagnosis code.
+
+## Generated Files
+
+Do not commit `__pycache__`, rendered videos, or temporary correction artifacts unless they are intentional demo outputs.

--- a/Problem1_ForearmLength/README.md
+++ b/Problem1_ForearmLength/README.md
@@ -74,6 +74,10 @@ SimCorrect identifies the forearm as the faulty parameter and corrects it throug
     Part('forearm').extrude(Sketch().circle(r=0.028), depth=0.38).export('forearm.stl')
     sim.reload('forearm.stl')
 
+The CAID artifact path is now the preferred integration path. OpenCAD exports a `caid-design.json` artifact with a company-facing `forearm_length` parameter mapped to this problem's MuJoCo `link2_length` parameter. If `CAID_DESIGN_ARTIFACT` is set, `correction_and_validation.py` creates a structured parameter patch from the identification result and uses that patch to produce corrected simulation parameters.
+
+    CAID_DESIGN_ARTIFACT=caid-design.json python correction_and_validation.py
+
 No human writes the correction. No human touches a file.
 
 ---
@@ -134,7 +138,7 @@ No human writes the correction. No human touches a file.
     cd Problem1_ForearmLength
     python3 render_demo.py
 
-    pip install mujoco numpy pillow imageio[ffmpeg]
+    uv pip install mujoco numpy pillow "imageio[ffmpeg]"
 
 ---
 

--- a/Problem1_ForearmLength/caid_loop.py
+++ b/Problem1_ForearmLength/caid_loop.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from caid_contract import (
+    apply_parameter_patch,
+    apply_patch_to_simulation_params,
+    load_artifact,
+    make_patch_from_identification,
+)
+
+
+@dataclass(frozen=True)
+class CaidCorrection:
+    corrected_params: dict[str, Any]
+    patch: dict[str, Any]
+    corrected_artifact: dict[str, Any]
+
+
+def correct_params_from_artifact(
+    artifact_source: str | Path | dict[str, Any],
+    identification_result: dict[str, Any],
+    current_params: dict[str, Any],
+) -> CaidCorrection:
+    artifact = load_artifact(artifact_source)
+    patch = make_patch_from_identification(artifact, identification_result)
+    corrected_artifact = apply_parameter_patch(artifact, patch)
+    corrected_params = apply_patch_to_simulation_params(artifact, patch, current_params)
+    return CaidCorrection(
+        corrected_params=corrected_params,
+        patch=patch,
+        corrected_artifact=corrected_artifact,
+    )

--- a/Problem1_ForearmLength/correction_and_validation.py
+++ b/Problem1_ForearmLength/correction_and_validation.py
@@ -6,14 +6,19 @@ Reruns simulation and validates convergence.
 Plots before vs after.
 """
 
+import json
+import os
+import tempfile
+
+import matplotlib.gridspec as gridspec
+import matplotlib.pyplot as plt
 import mujoco
 import numpy as np
-import tempfile
-import os
-import json
-import matplotlib.pyplot as plt
-import matplotlib.gridspec as gridspec
-from opencad import Part, Sketch
+
+try:
+    from .caid_loop import correct_params_from_artifact
+except ImportError:
+    from caid_loop import correct_params_from_artifact
 
 ROBOT_XML_TEMPLATE = """
 <mujoco model="simple_arm">
@@ -69,7 +74,7 @@ def run_simulation(params, duration=3.0, log_hz=100.0):
             ee_log.append(data.site_xpos[ee_id].copy())
     return np.array(times), np.array(log), np.array(ee_log)
 
-def opencad_correction(identification_result, current_params):
+def opencad_correction(identification_result, current_params, artifact=None):
     """
     Use OpenCAD to apply the parameter correction.
     Records the correction in the feature tree for audit trail.
@@ -77,24 +82,22 @@ def opencad_correction(identification_result, current_params):
     param = identification_result["identified_parameter"]
     proposed_value = identification_result["proposed_value"]
 
+    if artifact is not None:
+        result = correct_params_from_artifact(artifact, identification_result, current_params)
+        print(f"\nOpenCAD correction:")
+        print(f"  Simulation parameter: {param}")
+        print(f"  Patch parameter:      {result.patch['parameter_patches'][0]['name']}")
+        print(f"  From: {current_params[param]:.5f}m")
+        print(f"  To:   {proposed_value:.5f}m")
+        print(f"  CAID artifact patch prepared.")
+        return result.corrected_params
+
     print(f"\nOpenCAD correction:")
     print(f"  Parameter: {param}")
     print(f"  From: {current_params[param]:.5f}m")
     print(f"  To:   {proposed_value:.5f}m")
 
-    # Use OpenCAD feature tree to record the correction
-    # This creates an auditable parametric history of the fix
-    arm_profile = (
-        Sketch(name="Arm Correction Record")
-        .rect(proposed_value * 100, 4)   # scaled for CAD units (cm)
-    )
-    Part(name=f"Corrected_{param}").extrude(
-        arm_profile,
-        depth=4,
-        name=f"Correction: {param} = {proposed_value:.4f}m"
-    )
-
-    print(f"  OpenCAD feature tree updated — correction logged.")
+    print("  CAID artifact not set; applying simulation parameter directly.")
 
     # Apply correction to simulation parameters
     corrected_params = current_params.copy()
@@ -180,7 +183,8 @@ if __name__ == "__main__":
     gt_params     = {"link1_length": 0.30, "link2_length": 0.25}
 
     # Phase 4 — OpenCAD correction
-    corrected_params = opencad_correction(identification_result, faulty_params)
+    artifact_path = os.environ.get("CAID_DESIGN_ARTIFACT")
+    corrected_params = opencad_correction(identification_result, faulty_params, artifact=artifact_path)
     print(f"\nCorrected params: {corrected_params}")
 
     # Phase 5 — Rerun simulation with corrected params

--- a/README.md
+++ b/README.md
@@ -65,12 +65,14 @@ Three of the five faults are completely invisible in joint space and undetectabl
 OpenCAD is the correction engine at the core of SimCorrect. It provides a programmatic interface for modifying simulation model parameters directly from fault identification results.
 
 ```python
-from opencad import Part
+from mjcf_correction import Part
 Part('grip').set_mass(0.160).export('grip_corrected.xml')
 Part('joint1').set_ref(0.0000).export('joint1_corrected.xml')
 ```
 
 The correction record is written to an XML file, the simulation reloads the corrected model, and the validation pipeline confirms the fault is eliminated before the result is accepted.
+
+The older `from opencad import Part` import remains as a compatibility facade, but new MJCF correction code should use `mjcf_correction` so it is not confused with the full OpenCAD package.
 
 SimCorrect can also consume the CAID design artifact exported by OpenCAD 0.1.1. The artifact gives the correction loop stable parameter names instead of forcing each problem script to infer values from ad hoc files.
 
@@ -85,6 +87,8 @@ corrected_artifact = apply_parameter_patch(artifact, patch)
 The patch is structured JSON and can be sent back to OpenCAD to update named design parameters. If SimCorrect identifies an internal simulation target such as `link2_length`, the artifact can map it to a company-facing parameter such as `forearm_length` through a `kind="parameter"` simulation tag.
 
 Problem 1 now uses this path when `CAID_DESIGN_ARTIFACT` points at an OpenCAD artifact. Its pure helper lives in `Problem1_ForearmLength/caid_loop.py`, so the artifact-to-patch behavior can be tested without MuJoCo or rendering.
+
+The contract semantics are documented in [`docs/CAID_ARTIFACT_CONTRACT.md`](docs/CAID_ARTIFACT_CONTRACT.md).
 
 ---
 
@@ -114,11 +118,13 @@ python render_demo.py
 
 ## Repository Structure
 
-The repository is organized into five self-contained problem folders, each representing one fault scenario. A shared OpenCAD module lives at the root and is imported by all five problems. Every problem folder follows the same structure.
+The repository is organized into five self-contained problem folders, each representing one fault scenario. Shared contract and MJCF correction helpers live at the root. Every problem folder follows the same structure.
 
 ```text
 SimCorrect/
-├── opencad.py
+├── caid_contract.py
+├── mjcf_correction.py
+├── opencad.py              # compatibility facade
 ├── Problem1_ForearmLength/
 │   ├── render_demo.py
 │   ├── sim_pair.py

--- a/README.md
+++ b/README.md
@@ -72,16 +72,31 @@ Part('joint1').set_ref(0.0000).export('joint1_corrected.xml')
 
 The correction record is written to an XML file, the simulation reloads the corrected model, and the validation pipeline confirms the fault is eliminated before the result is accepted.
 
+SimCorrect can also consume the CAID design artifact exported by OpenCAD 0.1.1. The artifact gives the correction loop stable parameter names instead of forcing each problem script to infer values from ad hoc files.
+
+```python
+from opencad import apply_parameter_patch, load_artifact, make_patch_from_identification
+
+artifact = load_artifact("caid-design.json")
+patch = make_patch_from_identification(artifact, identification_result)
+corrected_artifact = apply_parameter_patch(artifact, patch)
+```
+
+The patch is structured JSON and can be sent back to OpenCAD to update named design parameters. If SimCorrect identifies an internal simulation target such as `link2_length`, the artifact can map it to a company-facing parameter such as `forearm_length` through a `kind="parameter"` simulation tag.
+
+Problem 1 now uses this path when `CAID_DESIGN_ARTIFACT` points at an OpenCAD artifact. Its pure helper lives in `Problem1_ForearmLength/caid_loop.py`, so the artifact-to-patch behavior can be tested without MuJoCo or rendering.
+
 ---
 
 ## Installation
 
+For development and contract tests, see `CONTRIBUTING.md`.
+
 ```bash
 git clone https://github.com/caid-technologies/SimCorrect.git
 cd SimCorrect
-conda create -n simcorrect python=3.10
-conda activate simcorrect
-pip install mujoco numpy pillow imageio[ffmpeg]
+uv venv --python 3.10
+uv pip install mujoco numpy pillow "imageio[ffmpeg]"
 ```
 
 ---

--- a/caid_contract.py
+++ b/caid_contract.py
@@ -1,0 +1,206 @@
+from __future__ import annotations
+
+import json
+from copy import deepcopy
+from pathlib import Path
+from typing import Any
+
+SCHEMA_VERSION = 1
+
+__all__ = [
+    "SCHEMA_VERSION",
+    "ContractError",
+    "apply_parameter_patch",
+    "apply_patch_to_simulation_params",
+    "get_parameter",
+    "load_artifact",
+    "make_parameter_patch",
+    "make_patch_from_identification",
+    "resolve_parameter_name",
+    "simulation_target_for_parameter",
+    "write_json",
+]
+
+
+class ContractError(ValueError):
+    """Raised when a CAID artifact or patch violates the integration contract."""
+
+
+def load_artifact(source: str | Path | dict[str, Any]) -> dict[str, Any]:
+    artifact = _load_json(source)
+    _require_artifact(artifact)
+    return artifact
+
+
+def get_parameter(artifact: dict[str, Any], name: str) -> dict[str, Any]:
+    _require_artifact(artifact)
+    try:
+        parameter = artifact["parameters"][name]
+    except KeyError as exc:
+        raise ContractError(f"Unknown design parameter '{name}'.") from exc
+    if not isinstance(parameter, dict) or "value" not in parameter:
+        raise ContractError(f"Design parameter '{name}' is malformed.")
+    return parameter
+
+
+def resolve_parameter_name(artifact: dict[str, Any], name_or_target: str) -> str:
+    _require_artifact(artifact)
+    if name_or_target in artifact["parameters"]:
+        return name_or_target
+
+    for tag in artifact.get("simulation_tags", []):
+        if tag.get("kind") == "parameter" and tag.get("target") == name_or_target:
+            name = tag.get("name")
+            if name in artifact["parameters"]:
+                return name
+
+    raise ContractError(f"Unknown design parameter or simulation target '{name_or_target}'.")
+
+
+def simulation_target_for_parameter(artifact: dict[str, Any], name: str) -> str:
+    _require_artifact(artifact)
+    get_parameter(artifact, name)
+    for tag in artifact.get("simulation_tags", []):
+        if tag.get("kind") == "parameter" and tag.get("name") == name:
+            target = tag.get("target")
+            if isinstance(target, str) and target:
+                return target
+            raise ContractError(f"Simulation tag for '{name}' is missing a target.")
+    return name
+
+
+def make_parameter_patch(
+    artifact: dict[str, Any],
+    name: str,
+    value: bool | int | float | str,
+    *,
+    reason: str | None = None,
+    source: str = "simcorrect",
+) -> dict[str, Any]:
+    parameter = get_parameter(artifact, name)
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "artifact_id": artifact["artifact_id"],
+        "source": source,
+        "parameter_patches": [
+            {
+                "name": name,
+                "old_value": parameter["value"],
+                "value": value,
+                "reason": reason,
+            }
+        ],
+    }
+
+
+def make_patch_from_identification(
+    artifact: dict[str, Any],
+    identification: dict[str, Any],
+    *,
+    source: str = "simcorrect",
+) -> dict[str, Any]:
+    missing = [key for key in ("identified_parameter", "proposed_value") if key not in identification]
+    if missing:
+        raise ContractError(f"Identification result missing required key(s): {', '.join(missing)}.")
+    name = resolve_parameter_name(artifact, identification["identified_parameter"])
+    return make_parameter_patch(
+        artifact,
+        name,
+        identification["proposed_value"],
+        reason=f"{identification.get('method', 'parameter_identification')} identified {identification['identified_parameter']}.",
+        source=source,
+    )
+
+
+def apply_parameter_patch(artifact: dict[str, Any], patch: dict[str, Any]) -> dict[str, Any]:
+    _require_artifact(artifact)
+    _require_patch(patch)
+    _require_patch_targets_artifact(artifact, patch)
+
+    updated = deepcopy(artifact)
+    for item in patch["parameter_patches"]:
+        parameter = get_parameter(updated, item["name"])
+        _require_current_value(parameter, item)
+        parameter["value"] = item["value"]
+
+    return updated
+
+
+def apply_patch_to_simulation_params(
+    artifact: dict[str, Any],
+    patch: dict[str, Any],
+    params: dict[str, Any],
+) -> dict[str, Any]:
+    _require_artifact(artifact)
+    _require_patch(patch)
+    _require_patch_targets_artifact(artifact, patch)
+    updated = dict(params)
+    for item in patch["parameter_patches"]:
+        parameter = get_parameter(artifact, item["name"])
+        _require_current_value(parameter, item)
+        target = simulation_target_for_parameter(artifact, item["name"])
+        if target not in updated:
+            raise ContractError(f"Simulation parameter '{target}' is not present in current params.")
+        updated[target] = item["value"]
+    return updated
+
+
+def write_json(payload: dict[str, Any], path: str | Path) -> None:
+    Path(path).write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def _load_json(source: str | Path | dict[str, Any]) -> dict[str, Any]:
+    if isinstance(source, dict):
+        return deepcopy(source)
+    payload = json.loads(Path(source).read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise ContractError("CAID JSON payload must be an object.")
+    return payload
+
+
+def _require_version(payload: dict[str, Any]) -> None:
+    if payload.get("schema_version") != SCHEMA_VERSION:
+        raise ContractError(f"Unsupported CAID schema_version: {payload.get('schema_version')!r}.")
+
+
+def _require_artifact(payload: dict[str, Any]) -> None:
+    _require_version(payload)
+    if not isinstance(payload.get("artifact_id"), str) or not payload["artifact_id"]:
+        raise ContractError("CAID artifact must contain a non-empty artifact_id.")
+    if not isinstance(payload.get("parameters"), dict):
+        raise ContractError("CAID artifact must contain a parameters object.")
+    if "simulation_tags" in payload and not isinstance(payload["simulation_tags"], list):
+        raise ContractError("CAID artifact simulation_tags must be a list when present.")
+
+
+def _require_patch(payload: dict[str, Any]) -> None:
+    _require_version(payload)
+    if not isinstance(payload.get("artifact_id"), str) or not payload["artifact_id"]:
+        raise ContractError("CAID patch must contain a non-empty artifact_id.")
+    patches = payload.get("parameter_patches")
+    if not isinstance(patches, list) or not patches:
+        raise ContractError("CAID patch must contain at least one parameter patch.")
+    for item in patches:
+        _require_patch_item(item)
+
+
+def _require_patch_item(item: Any) -> None:
+    if not isinstance(item, dict):
+        raise ContractError("Each parameter patch must be an object.")
+    if not isinstance(item.get("name"), str) or not item["name"]:
+        raise ContractError("Each parameter patch must contain a non-empty name.")
+    if "value" not in item:
+        raise ContractError(f"Parameter patch '{item.get('name')}' is missing value.")
+
+
+def _require_patch_targets_artifact(artifact: dict[str, Any], patch: dict[str, Any]) -> None:
+    if patch.get("artifact_id") != artifact.get("artifact_id"):
+        raise ContractError("Patch artifact_id does not match artifact.")
+
+
+def _require_current_value(parameter: dict[str, Any], item: dict[str, Any]) -> None:
+    if item.get("old_value") is not None and item["old_value"] != parameter["value"]:
+        raise ContractError(
+            f"Patch for '{item['name']}' expected old value {item['old_value']!r}, "
+            f"but artifact has {parameter['value']!r}."
+        )

--- a/docs/CAID_ARTIFACT_CONTRACT.md
+++ b/docs/CAID_ARTIFACT_CONTRACT.md
@@ -1,0 +1,92 @@
+# CAID Artifact Contract
+
+Schema version: `1`
+
+The CAID artifact is the stable boundary between OpenCAD and SimCorrect. OpenCAD owns design artifacts and applies design patches. SimCorrect consumes artifacts, identifies simulation faults, and returns patches against named design parameters.
+
+## Design Artifact
+
+Required top-level fields:
+
+```json
+{
+  "schema_version": 1,
+  "artifact_id": "simcorrect-problem1-forearm",
+  "producer": {"name": "opencad", "version": "0.1.1"},
+  "created_at": "2026-04-24T00:00:00Z",
+  "feature_tree": {"root_id": "root", "nodes": {}},
+  "parameters": {},
+  "simulation_tags": []
+}
+```
+
+`artifact_id` is the identity used to reject patches for the wrong design. `feature_tree` is the OpenCAD reconstruction history. `parameters` contains the design-level values SimCorrect may patch.
+
+Each parameter is keyed by name and must contain a matching `name` and a `value`:
+
+```json
+{
+  "forearm_length": {
+    "name": "forearm_length",
+    "value": 0.25,
+    "unit": "m",
+    "role": "geometry",
+    "feature_id": "feat-forearm"
+  }
+}
+```
+
+## Simulation Tags
+
+Simulation tags map design names to simulator names without hardcoding aliases in diagnosis code.
+
+```json
+{
+  "name": "forearm_length",
+  "kind": "parameter",
+  "target": "link2_length"
+}
+```
+
+For schema version `1`, SimCorrect uses `kind="parameter"` tags to resolve an identified simulation parameter such as `link2_length` back to an OpenCAD parameter such as `forearm_length`.
+
+## Design Patch
+
+Patch payloads are structured JSON:
+
+```json
+{
+  "schema_version": 1,
+  "artifact_id": "simcorrect-problem1-forearm",
+  "source": "simcorrect",
+  "parameter_patches": [
+    {
+      "name": "forearm_length",
+      "old_value": 0.25,
+      "value": 0.30,
+      "reason": "sensitivity_analysis identified link2_length."
+    }
+  ]
+}
+```
+
+Patch rules:
+
+- `schema_version` must match the supported contract version.
+- `artifact_id` must match the artifact being patched.
+- `parameter_patches` must contain at least one item.
+- `name` must identify an existing design parameter.
+- `old_value`, when present and non-null, must match the current artifact value.
+- Applying a patch must not mutate the original artifact object in memory.
+
+The `old_value` check is intentionally strict. It catches stale SimCorrect corrections before they overwrite a newer OpenCAD design state.
+
+## Current Golden Slice
+
+The first validated slice is SimCorrect Problem 1:
+
+- OpenCAD parameter: `forearm_length`
+- SimCorrect target: `link2_length`
+- Expected patch: `forearm_length` from `0.25` to `0.30`
+
+OpenCAD covers this with `backend/opencad/tests/test_caid_golden_loop.py`. SimCorrect covers the corresponding fixture with `tests/test_golden_loop_fixture.py`.

--- a/mjcf_correction.py
+++ b/mjcf_correction.py
@@ -1,0 +1,157 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+import time
+import xml.etree.ElementTree as ET
+
+
+__all__ = ["CorrectionRecord", "Part"]
+
+
+@dataclass(frozen=True)
+class CorrectionRecord:
+    part_name: str
+    field: str
+    old_value: object
+    new_value: object
+    elapsed_s: float
+    timestamp: str = field(default_factory=lambda: time.strftime("%Y-%m-%dT%H:%M:%S"))
+
+    @classmethod
+    def create(
+        cls,
+        part_name: str,
+        field: str,
+        old_value: object,
+        new_value: object,
+        elapsed_s: float,
+    ) -> "CorrectionRecord":
+        return cls(
+            part_name=part_name,
+            field=field,
+            old_value=old_value,
+            new_value=new_value,
+            elapsed_s=elapsed_s,
+        )
+
+    def __repr__(self) -> str:
+        return (
+            f"CorrectionRecord(part={self.part_name!r}, "
+            f"field={self.field!r}, "
+            f"{self.old_value} -> {self.new_value}, "
+            f"{self.elapsed_s * 1000:.1f}ms)"
+        )
+
+
+class Part:
+    """Fluent helper for MJCF body mass and joint reference corrections."""
+
+    def __init__(self, name: str, xml_source: str | None = None):
+        self.name = name
+        self.xml_source = xml_source
+        self._mass: float | None = None
+        self._ref: float | None = None
+        self._corrections: list[CorrectionRecord] = []
+        self._tree: ET.ElementTree | None = None
+        self._root: ET.Element | None = None
+        self._t0 = time.perf_counter()
+        if xml_source and Path(xml_source).exists():
+            self._tree = ET.parse(xml_source)
+            self._root = self._tree.getroot()
+
+    def set_mass(self, mass_kg: float) -> "Part":
+        self._mass = float(mass_kg)
+        return self
+
+    def set_ref(self, ref_rad: float) -> "Part":
+        self._ref = float(ref_rad)
+        return self
+
+    def export(self, output_path: str) -> "Part":
+        elapsed = time.perf_counter() - self._t0
+        if self._tree is not None and self._root is not None:
+            self._apply_to_tree(elapsed)
+            self._tree.write(output_path, encoding="unicode", xml_declaration=False)
+        else:
+            self._write_record_xml(output_path, elapsed)
+        return self
+
+    @property
+    def corrections(self) -> list[CorrectionRecord]:
+        return list(self._corrections)
+
+    def report(self) -> str:
+        lines = [f"OpenCAD correction - part: {self.name!r}"]
+        if not self._corrections:
+            lines.append("  No corrections recorded.")
+        for record in self._corrections:
+            lines.append(
+                f"  {record.field}: {record.old_value} -> {record.new_value}"
+                f"  ({record.elapsed_s * 1000:.1f}ms)"
+            )
+        return "\n".join(lines)
+
+    def _apply_to_tree(self, elapsed: float) -> None:
+        if self._root is None:
+            return
+        if self._mass is not None:
+            self._apply_mass(elapsed)
+        if self._ref is not None:
+            self._apply_ref(elapsed)
+
+    def _apply_mass(self, elapsed: float) -> None:
+        if self._root is None or self._mass is None:
+            return
+        for body in self._root.iter("body"):
+            if body.get("name") != self.name:
+                continue
+            inertial = body.find("inertial")
+            if inertial is None:
+                inertial = ET.SubElement(body, "inertial")
+            old = inertial.get("mass", "unknown")
+            inertial.set("mass", f"{self._mass:.6f}")
+            self._corrections.append(
+                CorrectionRecord.create(self.name, "inertial.mass", old, self._mass, elapsed)
+            )
+            return
+
+    def _apply_ref(self, elapsed: float) -> None:
+        if self._root is None or self._ref is None:
+            return
+        for joint in self._root.iter("joint"):
+            if joint.get("name") != self.name:
+                continue
+            old = joint.get("ref", "0.0")
+            joint.set("ref", f"{self._ref:.6f}")
+            self._corrections.append(
+                CorrectionRecord.create(self.name, "joint.ref", old, self._ref, elapsed)
+            )
+            return
+
+    def _write_record_xml(self, output_path: str, elapsed: float) -> None:
+        root = ET.Element("opencad_correction")
+        root.set("timestamp", time.strftime("%Y-%m-%dT%H:%M:%S"))
+        root.set("elapsed_s", f"{elapsed:.4f}")
+        part_el = ET.SubElement(root, "part")
+        part_el.set("name", self.name)
+        if self._mass is not None:
+            correction = ET.SubElement(part_el, "correction")
+            correction.set("field", "inertial.mass")
+            correction.set("value", f"{self._mass:.6f}")
+            correction.set("unit", "kg")
+            self._corrections.append(
+                CorrectionRecord.create(self.name, "inertial.mass", "unknown", self._mass, elapsed)
+            )
+        if self._ref is not None:
+            correction = ET.SubElement(part_el, "correction")
+            correction.set("field", "joint.ref")
+            correction.set("value", f"{self._ref:.6f}")
+            correction.set("unit", "rad")
+            self._corrections.append(
+                CorrectionRecord.create(self.name, "joint.ref", "unknown", self._ref, elapsed)
+            )
+        ET.ElementTree(root).write(output_path, encoding="unicode", xml_declaration=True)
+
+    def __repr__(self) -> str:
+        return f"Part({self.name!r}, mass={self._mass}, ref={self._ref})"

--- a/opencad.py
+++ b/opencad.py
@@ -1,17 +1,8 @@
-"""
-OpenCAD — Autonomous model correction API for SimCorrect.
-The central abstraction between fault identification and deployment.
-SimCorrect identifies what is wrong and by how much.
-OpenCAD applies that correction to the simulation model.
+"""Compatibility facade for legacy SimCorrect OpenCAD imports.
 
-Usage:
-    from opencad import Part
-    Part('grip').set_mass(0.160).export('grip_corrected.xml')
-    Part('joint1').set_ref(0.0000).export('joint1_corrected.xml')
+New MJCF correction code should import from `mjcf_correction` directly. The
+CAID artifact helpers remain re-exported here so older scripts keep working.
 """
-import os
-import time
-import xml.etree.ElementTree as ET
 
 from caid_contract import (
     ContractError,
@@ -19,12 +10,13 @@ from caid_contract import (
     apply_patch_to_simulation_params,
     get_parameter,
     load_artifact,
-    make_patch_from_identification,
     make_parameter_patch,
+    make_patch_from_identification,
     resolve_parameter_name,
     simulation_target_for_parameter,
     write_json,
 )
+from mjcf_correction import CorrectionRecord, Part
 
 __all__ = [
     "ContractError",
@@ -40,118 +32,3 @@ __all__ = [
     "simulation_target_for_parameter",
     "write_json",
 ]
-
-
-class CorrectionRecord:
-    def __init__(self, part_name, field, old_value, new_value, elapsed_s):
-        self.part_name = part_name
-        self.field     = field
-        self.old_value = old_value
-        self.new_value = new_value
-        self.elapsed_s = elapsed_s
-        self.timestamp = time.strftime("%Y-%m-%dT%H:%M:%S")
-
-    def __repr__(self):
-        return (f"CorrectionRecord(part={self.part_name!r}, "
-                f"field={self.field!r}, "
-                f"{self.old_value} -> {self.new_value}, "
-                f"{self.elapsed_s*1000:.1f}ms)")
-
-
-class Part:
-    """
-    Fluent interface for correcting a named body or joint in a MuJoCo MJCF model.
-    """
-    def __init__(self, name: str, xml_source: str = None):
-        self.name         = name
-        self.xml_source   = xml_source
-        self._mass        = None
-        self._ref         = None
-        self._corrections = []
-        self._tree        = None
-        self._root        = None
-        self._t0          = time.perf_counter()
-        if xml_source and os.path.exists(xml_source):
-            self._tree = ET.parse(xml_source)
-            self._root = self._tree.getroot()
-
-    def set_mass(self, mass_kg: float) -> "Part":
-        self._mass = float(mass_kg)
-        return self
-
-    def set_ref(self, ref_rad: float) -> "Part":
-        self._ref = float(ref_rad)
-        return self
-
-    def export(self, output_path: str) -> "Part":
-        elapsed = time.perf_counter() - self._t0
-        if self._root is not None:
-            self._apply_to_tree(elapsed)
-            self._tree.write(output_path, encoding="unicode", xml_declaration=False)
-        else:
-            self._write_record_xml(output_path, elapsed)
-        return self
-
-    def _apply_to_tree(self, elapsed):
-        if self._mass is not None:
-            for body in self._root.iter("body"):
-                if body.get("name") == self.name:
-                    inertial = body.find("inertial")
-                    if inertial is None:
-                        inertial = ET.SubElement(body, "inertial")
-                    old = inertial.get("mass", "unknown")
-                    inertial.set("mass", f"{self._mass:.6f}")
-                    self._corrections.append(
-                        CorrectionRecord(self.name, "inertial.mass",
-                                         old, self._mass, elapsed))
-                    break
-        if self._ref is not None:
-            for joint in self._root.iter("joint"):
-                if joint.get("name") == self.name:
-                    old = joint.get("ref", "0.0")
-                    joint.set("ref", f"{self._ref:.6f}")
-                    self._corrections.append(
-                        CorrectionRecord(self.name, "joint.ref",
-                                         old, self._ref, elapsed))
-                    break
-
-    def _write_record_xml(self, output_path, elapsed):
-        root = ET.Element("opencad_correction")
-        root.set("timestamp", time.strftime("%Y-%m-%dT%H:%M:%S"))
-        root.set("elapsed_s", f"{elapsed:.4f}")
-        part_el = ET.SubElement(root, "part")
-        part_el.set("name", self.name)
-        if self._mass is not None:
-            c = ET.SubElement(part_el, "correction")
-            c.set("field", "inertial.mass")
-            c.set("value", f"{self._mass:.6f}")
-            c.set("unit", "kg")
-            self._corrections.append(
-                CorrectionRecord(self.name, "inertial.mass",
-                                 "unknown", self._mass, elapsed))
-        if self._ref is not None:
-            c = ET.SubElement(part_el, "correction")
-            c.set("field", "joint.ref")
-            c.set("value", f"{self._ref:.6f}")
-            c.set("unit", "rad")
-            self._corrections.append(
-                CorrectionRecord(self.name, "joint.ref",
-                                 "unknown", self._ref, elapsed))
-        ET.ElementTree(root).write(output_path, encoding="unicode",
-                                   xml_declaration=True)
-
-    def report(self) -> str:
-        lines = [f"OpenCAD correction — part: {self.name!r}"]
-        if not self._corrections:
-            lines.append("  No corrections recorded.")
-        for r in self._corrections:
-            lines.append(f"  {r.field}: {r.old_value} -> {r.new_value}"
-                         f"  ({r.elapsed_s*1000:.1f}ms)")
-        return "\n".join(lines)
-
-    @property
-    def corrections(self):
-        return list(self._corrections)
-
-    def __repr__(self):
-        return f"Part({self.name!r}, mass={self._mass}, ref={self._ref})"

--- a/opencad.py
+++ b/opencad.py
@@ -9,8 +9,37 @@ Usage:
     Part('grip').set_mass(0.160).export('grip_corrected.xml')
     Part('joint1').set_ref(0.0000).export('joint1_corrected.xml')
 """
+import os
+import time
 import xml.etree.ElementTree as ET
-import os, time
+
+from caid_contract import (
+    ContractError,
+    apply_parameter_patch,
+    apply_patch_to_simulation_params,
+    get_parameter,
+    load_artifact,
+    make_patch_from_identification,
+    make_parameter_patch,
+    resolve_parameter_name,
+    simulation_target_for_parameter,
+    write_json,
+)
+
+__all__ = [
+    "ContractError",
+    "CorrectionRecord",
+    "Part",
+    "apply_parameter_patch",
+    "apply_patch_to_simulation_params",
+    "get_parameter",
+    "load_artifact",
+    "make_parameter_patch",
+    "make_patch_from_identification",
+    "resolve_parameter_name",
+    "simulation_target_for_parameter",
+    "write_json",
+]
 
 
 class CorrectionRecord:

--- a/tests/fixtures/opencad_forearm_artifact.json
+++ b/tests/fixtures/opencad_forearm_artifact.json
@@ -1,0 +1,29 @@
+{
+  "artifact_id": "simcorrect-problem1-forearm",
+  "created_at": "2026-04-24T00:00:00Z",
+  "feature_tree": {
+    "nodes": {},
+    "root_id": "root"
+  },
+  "parameters": {
+    "forearm_length": {
+      "feature_id": "feat-forearm",
+      "name": "forearm_length",
+      "role": "geometry",
+      "unit": "m",
+      "value": 0.25
+    }
+  },
+  "producer": {
+    "name": "opencad",
+    "version": "0.1.1"
+  },
+  "schema_version": 1,
+  "simulation_tags": [
+    {
+      "kind": "parameter",
+      "name": "forearm_length",
+      "target": "link2_length"
+    }
+  ]
+}

--- a/tests/test_caid_contract.py
+++ b/tests/test_caid_contract.py
@@ -1,0 +1,153 @@
+from __future__ import annotations
+
+import unittest
+
+from caid_contract import (
+    ContractError,
+    apply_parameter_patch,
+    apply_patch_to_simulation_params,
+    get_parameter,
+    load_artifact,
+    make_parameter_patch,
+    make_patch_from_identification,
+    resolve_parameter_name,
+    simulation_target_for_parameter,
+)
+
+
+def sample_artifact():
+    return {
+        "schema_version": 1,
+        "artifact_id": "forearm-demo",
+        "producer": {"name": "opencad", "version": "0.1.1"},
+        "feature_tree": {"root_id": "root", "nodes": {}},
+        "parameters": {
+            "forearm_length": {
+                "name": "forearm_length",
+                "value": 0.25,
+                "unit": "m",
+                "role": "geometry",
+                "feature_id": "feat-0001",
+            }
+        },
+        "simulation_tags": [
+            {"name": "right_forearm", "kind": "body", "target": "r_forearm"},
+            {"name": "forearm_length", "kind": "parameter", "target": "link2_length"},
+        ],
+    }
+
+
+class CaidContractTests(unittest.TestCase):
+    def test_load_and_read_parameter(self):
+        artifact = load_artifact(sample_artifact())
+
+        parameter = get_parameter(artifact, "forearm_length")
+
+        self.assertEqual(parameter["value"], 0.25)
+        self.assertEqual(parameter["unit"], "m")
+
+    def test_make_and_apply_parameter_patch(self):
+        artifact = load_artifact(sample_artifact())
+        patch = make_parameter_patch(
+            artifact,
+            "forearm_length",
+            0.30,
+            reason="Vertical overshoot isolated to forearm length.",
+        )
+
+        updated = apply_parameter_patch(artifact, patch)
+
+        self.assertEqual(patch["artifact_id"], "forearm-demo")
+        self.assertEqual(patch["parameter_patches"][0]["old_value"], 0.25)
+        self.assertEqual(updated["parameters"]["forearm_length"]["value"], 0.30)
+        self.assertEqual(artifact["parameters"]["forearm_length"]["value"], 0.25)
+
+    def test_patch_rejects_wrong_artifact(self):
+        artifact = load_artifact(sample_artifact())
+        patch = make_parameter_patch(artifact, "forearm_length", 0.30)
+        patch["artifact_id"] = "other-design"
+
+        with self.assertRaises(ContractError):
+            apply_parameter_patch(artifact, patch)
+
+    def test_patch_rejects_stale_old_value(self):
+        artifact = load_artifact(sample_artifact())
+        patch = make_parameter_patch(artifact, "forearm_length", 0.30)
+        patch["parameter_patches"][0]["old_value"] = 0.20
+
+        with self.assertRaisesRegex(ContractError, "expected old value"):
+            apply_parameter_patch(artifact, patch)
+
+    def test_patch_rejects_empty_parameter_patches(self):
+        artifact = load_artifact(sample_artifact())
+
+        with self.assertRaises(ContractError):
+            apply_parameter_patch(
+                artifact,
+                {
+                    "schema_version": 1,
+                    "artifact_id": "forearm-demo",
+                    "parameter_patches": [],
+                },
+            )
+
+    def test_identification_requires_target_and_value(self):
+        artifact = load_artifact(sample_artifact())
+
+        with self.assertRaises(ContractError):
+            make_patch_from_identification(artifact, {"identified_parameter": "link2_length"})
+
+    def test_identification_patch_resolves_sim_parameter_target(self):
+        artifact = load_artifact(sample_artifact())
+        identification = {
+            "identified_parameter": "link2_length",
+            "proposed_value": 0.30,
+            "method": "sensitivity_analysis",
+        }
+
+        patch = make_patch_from_identification(artifact, identification)
+
+        self.assertEqual(resolve_parameter_name(artifact, "link2_length"), "forearm_length")
+        self.assertEqual(simulation_target_for_parameter(artifact, "forearm_length"), "link2_length")
+        self.assertEqual(patch["parameter_patches"][0]["name"], "forearm_length")
+        self.assertEqual(patch["parameter_patches"][0]["value"], 0.30)
+
+    def test_patch_updates_simulation_params_via_tag(self):
+        artifact = load_artifact(sample_artifact())
+        patch = make_parameter_patch(artifact, "forearm_length", 0.30)
+
+        updated = apply_patch_to_simulation_params(
+            artifact,
+            patch,
+            {"link1_length": 0.30, "link2_length": 0.25},
+        )
+
+        self.assertEqual(updated["link2_length"], 0.30)
+
+    def test_simulation_params_reject_wrong_artifact_patch(self):
+        artifact = load_artifact(sample_artifact())
+        patch = make_parameter_patch(artifact, "forearm_length", 0.30)
+        patch["artifact_id"] = "other-design"
+
+        with self.assertRaises(ContractError):
+            apply_patch_to_simulation_params(
+                artifact,
+                patch,
+                {"link1_length": 0.30, "link2_length": 0.25},
+            )
+
+    def test_simulation_params_reject_stale_patch(self):
+        artifact = load_artifact(sample_artifact())
+        patch = make_parameter_patch(artifact, "forearm_length", 0.30)
+        patch["parameter_patches"][0]["old_value"] = 0.20
+
+        with self.assertRaisesRegex(ContractError, "expected old value"):
+            apply_patch_to_simulation_params(
+                artifact,
+                patch,
+                {"link1_length": 0.30, "link2_length": 0.25},
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_golden_loop_fixture.py
+++ b/tests/test_golden_loop_fixture.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+from pathlib import Path
+import unittest
+
+from caid_contract import (
+    apply_parameter_patch,
+    apply_patch_to_simulation_params,
+    load_artifact,
+    make_patch_from_identification,
+)
+
+
+FIXTURE = Path(__file__).parent / "fixtures" / "opencad_forearm_artifact.json"
+
+
+class GoldenLoopFixtureTests(unittest.TestCase):
+    def test_opencad_artifact_fixture_produces_simcorrect_patch(self):
+        artifact = load_artifact(FIXTURE)
+        identification = {
+            "identified_parameter": "link2_length",
+            "current_value": 0.25,
+            "proposed_value": 0.30,
+            "method": "sensitivity_analysis",
+        }
+
+        patch = make_patch_from_identification(artifact, identification)
+        corrected_artifact = apply_parameter_patch(artifact, patch)
+        corrected_params = apply_patch_to_simulation_params(
+            artifact,
+            patch,
+            {"link1_length": 0.30, "link2_length": 0.25},
+        )
+
+        self.assertEqual(patch["artifact_id"], "simcorrect-problem1-forearm")
+        self.assertEqual(patch["parameter_patches"][0]["name"], "forearm_length")
+        self.assertEqual(patch["parameter_patches"][0]["old_value"], 0.25)
+        self.assertEqual(patch["parameter_patches"][0]["value"], 0.30)
+        self.assertEqual(corrected_artifact["parameters"]["forearm_length"]["value"], 0.30)
+        self.assertEqual(corrected_params["link2_length"], 0.30)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_mjcf_correction.py
+++ b/tests/test_mjcf_correction.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+import unittest
+from unittest.mock import patch
+import xml.etree.ElementTree as ET
+
+from mjcf_correction import Part
+from opencad import Part as CompatPart
+
+
+class MjcfCorrectionTests(unittest.TestCase):
+    def test_explicit_module_writes_correction_record(self):
+        with patch.object(ET.ElementTree, "write") as write:
+            part = Part("grip").set_mass(0.160).export("mjcf_correction_test.xml")
+
+        write.assert_called_once_with(
+            "mjcf_correction_test.xml",
+            encoding="unicode",
+            xml_declaration=True,
+        )
+
+        self.assertEqual(part.corrections[0].field, "inertial.mass")
+        self.assertEqual(part.corrections[0].new_value, 0.160)
+
+    def test_legacy_opencad_import_still_exports_part(self):
+        self.assertIs(CompatPart, Part)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_problem1_caid_loop.py
+++ b/tests/test_problem1_caid_loop.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+import unittest
+
+from Problem1_ForearmLength.caid_loop import correct_params_from_artifact
+
+
+def forearm_artifact():
+    return {
+        "schema_version": 1,
+        "artifact_id": "forearm-demo",
+        "producer": {"name": "opencad", "version": "0.1.1"},
+        "feature_tree": {"root_id": "root", "nodes": {}},
+        "parameters": {
+            "forearm_length": {
+                "name": "forearm_length",
+                "value": 0.25,
+                "unit": "m",
+                "role": "geometry",
+                "feature_id": "feat-0001",
+            }
+        },
+        "simulation_tags": [
+            {"name": "forearm_length", "kind": "parameter", "target": "link2_length"},
+        ],
+    }
+
+
+class Problem1CaidLoopTests(unittest.TestCase):
+    def test_link2_identification_updates_forearm_artifact_and_sim_params(self):
+        result = correct_params_from_artifact(
+            forearm_artifact(),
+            {
+                "identified_parameter": "link2_length",
+                "proposed_value": 0.30,
+                "method": "sensitivity_analysis",
+            },
+            {"link1_length": 0.30, "link2_length": 0.25},
+        )
+
+        self.assertEqual(result.patch["parameter_patches"][0]["name"], "forearm_length")
+        self.assertEqual(result.corrected_artifact["parameters"]["forearm_length"]["value"], 0.30)
+        self.assertEqual(result.corrected_params["link2_length"], 0.30)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Summary: Adds the reusable CAID artifact contract adapter, keeps the existing OpenCAD shim compatible, wires Problem 1 through an OpenCAD artifact path, adds a golden OpenCAD artifact fixture, documents the uv-based contract workflow, adds GitHub Actions CI, and isolates local MJCF correction behavior in mjcf_correction.py behind a legacy opencad.py facade. Verification: uv --no-cache run --no-project python -m unittest discover -s tests => 14 passed.